### PR TITLE
chore: remove cli instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ steps:
   - label: "Skip checkout"
     command: 'echo "Skipping checkout"'
     plugins:
-      - custom-checkout#v1.0.0:
+      - custom-checkout#v1.1.0:
           skip_checkout: true
 ```
 
@@ -32,7 +32,7 @@ steps:
   - label: "Custom repository checkout"
     command: "buildkite-agent pipeline upload"
     plugins:
-      - custom-checkout#v1.0.0:
+      - custom-checkout#v1.1.0:
           skip_checkout: true
           repos:
             - url: "https://github.com/org/repo.git"
@@ -69,7 +69,7 @@ steps:
   - label: "Skip checkout"
     command: 'echo "Skipping checkout"'
     plugins:
-      - custom-checkout#v1.0.0:
+      - custom-checkout#v1.1.0:
           skip_checkout: true
 ```
 
@@ -80,7 +80,7 @@ steps:
   - label: "Custom checkout"
     command: "buildkite-agent pipeline upload"
     plugins:
-      - custom-checkout#v1.0.0:
+      - custom-checkout#v1.1.0:
           skip_checkout: true
           repos:
             - url: "https://github.com/org/repo.git"
@@ -93,7 +93,7 @@ steps:
   - label: "Multiple repos"
     command: "./script.sh"
     plugins:
-      - custom-checkout#v1.0.0:
+      - custom-checkout#v1.1.0:
           skip_checkout: true
           repos:
             - url: "https://github.com/org/repo1.git"

--- a/README.md
+++ b/README.md
@@ -102,13 +102,7 @@ steps:
               ref: "dev"
 ```
 
-## Developing
-
-To run testing, shellchecks and plugin linting use use `bk run` with the [Buildkite CLI](https://github.com/buildkite/cli).
-
-```bash
-bk run
-```
+## Testing
 
 ```bash
 docker-compose run --rm tests


### PR DESCRIPTION
## Changes

- The README references local development using the `bk` CLI tool (`bk run`), that's not a supported command in v3.x.x
    - v2.x.x of the CLI has been deprecated
