### PR TITLE
fix: fix array expansion to not include quotes

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -102,7 +102,7 @@ clone_repository() {
       git clone "$repo_url" .
     else
       log_info "Cloning with flags: ${clone_flags[*]}"
-      git clone "${clone_flags[@]}" "$repo_url" .
+      git clone ${clone_flags[@]} "$repo_url" .
     fi
   fi
 
@@ -194,7 +194,7 @@ while true; do
     fi
   done
 
-  if clone_repository "$REPO_URL" "$REPO_REF" "$REPO_SSH_KEY_PATH" "$BUILDKITE_BUILD_CHECKOUT_PATH" "${REPO_CLONE_FLAGS[@]+\"${REPO_CLONE_FLAGS[@]}\"}"; then
+  if clone_repository "$REPO_URL" "$REPO_REF" "$REPO_SSH_KEY_PATH" "$BUILDKITE_BUILD_CHECKOUT_PATH" "${REPO_CLONE_FLAGS[@]}"; then
     CLONE_SUCCESS=true
     log_success "Successfully cloned repository $REPO_URL"
   else

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -54,21 +54,21 @@ add_ssh_host() {
   # Check if host is already in known_hosts
   if ! grep -q "^$host" "$HOME/.ssh/known_hosts"; then
     log_info "$host not found in known_hosts"
-    
+
     # Get host key
     tmp_file=$(mktemp)
     ssh-keyscan -t rsa "$host" > "$tmp_file"
-    
+
     # Verify fingerprint
     local actual_fingerprint
     actual_fingerprint=$(ssh-keygen -lf "$tmp_file" | awk '{ print $2 }')
-    
+
     if [[ "$actual_fingerprint" != "$fingerprint" ]]; then
       log_error "Fingerprint mismatch for $host. Expected $fingerprint, got $actual_fingerprint."
       rm "$tmp_file"
       exit 1
     fi
-    
+
     # Add to known_hosts
     cat "$tmp_file" >> "$HOME/.ssh/known_hosts"
     rm "$tmp_file"
@@ -102,7 +102,7 @@ clone_repository() {
       git clone "$repo_url" .
     else
       log_info "Cloning with flags: ${clone_flags[*]}"
-      git clone ${clone_flags[@]} "$repo_url" .
+      git clone "${clone_flags[@]}" "$repo_url" .
     fi
   fi
 
@@ -133,7 +133,7 @@ log_section ":open_file_folder: Setting up workspace"
 # Check for skip checkout
 if [[ "${BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT:-false}" == "true" ]]; then
   log_warning "🚫 Skipping default checkout as per configuration."
-  
+
   # If we're just skipping checkout and no repos are specified, exit successfully
   if [[ -z "${BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0:-}" && -z "${BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL:-}" ]]; then
     log_info "📝 No repositories configured for checkout, skipping repository checkout"
@@ -166,17 +166,17 @@ CLONE_SUCCESS=false
 
 while true; do
   REPO_URL_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_URL"
-  
+
   if [[ -z "${!REPO_URL_VAR:-}" ]]; then
     REPO_URL_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}"
     if [[ -z "${!REPO_URL_VAR:-}" ]]; then
       break
     fi
   fi
-  
+
   REPO_URL="${!REPO_URL_VAR}"
   log_info "Processing repository $REPOS_COUNT: $REPO_URL"
-  
+
   REPO_REF_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_REF"
   REPO_SSH_KEY_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_SSH_KEY_PATH"
   REPO_REF="${!REPO_REF_VAR:-}"

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -59,6 +59,6 @@ teardown() {
 
   # Verify correct behavior
   [ "$status" -eq 0 ]
-  echo "$output" | grep 'Cloning with flags: "--depth=1"'
+  echo "$output" | grep 'Cloning with flags: --depth=1'
   cat "$MOCK_GIT_ARGS_FILE" | grep -- "--depth=1"
 }


### PR DESCRIPTION
## Changes

The way we were expanding our array meant that options were wrapped in quotes, this changes that ensures each flag is passed as its own argument.
