### PR TITLE
Fix repo clone flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ steps:
 
 Each repository in the `repos` list can have the following options:
 
-| Option        | Required | Default | Description                                 |
-|---------------|----------|---------|---------------------------------------------|
-| `url`         | true     |         | Repository Git URL                          |
-| `mirror_url`  | false    |         | Optional mirror URL for faster/local clone  |
-| `ref`         | false    |         | Branch, tag, or commit to checkout          |
-| `clone_flags` | false    | `[]`    | Additional flags for git clone              |
+| Option        | Required | Default  | Description                                 |
+|---------------|----------|--------- |---------------------------------------------|
+| `url`         | true     |          | Repository Git URL                          |
+| `mirror_url`  | false    |          | Optional mirror URL for faster/local clone  |
+| `ref`         | false    |          | Branch, tag, or commit to checkout          |
+| `clone_flags` | false    | `["-v"]` | Additional flags for git clone              |
 
 ## Examples
 

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -5,7 +5,7 @@ set -euo pipefail
 
 # Functions
 log_section() {
-  echo -e "\n🔷 --- $1"
+  echo -e "\n--- $1"
 }
 
 log_info() {
@@ -102,6 +102,7 @@ clone_repository() {
       git clone "${clone_flags[@]}" "$repo_url" .
     fi
   else
+    log_info "Clone flags: ${clone_flags[*]}"
     git clone "${clone_flags[@]}" "$repo_url" .
   fi
 
@@ -178,10 +179,26 @@ while true; do
   
   REPO_REF_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_REF"
   REPO_SSH_KEY_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_SSH_KEY_PATH"
-  
+
+  CLONE_FLAGS_COUNT=0
+  REPO_CLONE_FLAGS=()
+
+  REPO_CLONE_FLAGS_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_CLONE_FLAGS_${CLONE_FLAGS_COUNT}"
+  if [[ -z "${!REPO_CLONE_FLAGS_VAR:-}" ]]; then
+    REPO_CLONE_FLAGS=("-v")
+  fi
+
+  while true; do
+    REPO_CLONE_FLAGS_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_CLONE_FLAGS_${CLONE_FLAGS_COUNT}"
+    if [[ -z "${!REPO_CLONE_FLAGS_VAR:-}" ]]; then
+      break
+    fi
+    REPO_CLONE_FLAGS+=("${!REPO_CLONE_FLAGS_VAR}")
+    ((CLONE_FLAGS_COUNT++))
+  done
+
   REPO_REF="${!REPO_REF_VAR:-}"
   REPO_SSH_KEY_PATH="${!REPO_SSH_KEY_VAR:-}"
-  REPO_CLONE_FLAGS=()
   
   if clone_repository "$REPO_URL" "$REPO_REF" "$REPO_SSH_KEY_PATH" "$BUILDKITE_BUILD_CHECKOUT_PATH" "$REPO_MIRROR_URL" "${REPO_CLONE_FLAGS[@]+"${REPO_CLONE_FLAGS[@]}"}"; then
     CLONE_SUCCESS=true


### PR DESCRIPTION
* The `clone_flags` option was previously not being parsed under `repos`
* Fixed broken log heading parsing due to 🔷 at start of log line
* Default `clone_flags` to `["-v"]` to workaround `unbound variable` error present with certain `bash` versions