### PR TITLE
Remove meta-data setting [SUP-4422]

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -221,12 +221,6 @@ if [[ $REPOS_COUNT -eq 0 ]]; then
 fi
 
 if [[ "$CLONE_SUCCESS" == "true" ]]; then
-  if [[ -d ".git" ]]; then
-    if git rev-parse HEAD > /dev/null 2>&1; then
-      COMMIT=$(git rev-parse HEAD)
-      buildkite-agent meta-data set "buildkite:git:commit" "$COMMIT" || true
-    fi
-  fi
   log_info "All operations completed successfully"
   exit 0
 else


### PR DESCRIPTION
The setting of the metadata is both:
* unnecessary: the [agent sets it even when the checkout hook is overridden since version 3.67.0](https://github.com/buildkite/agent/pull/2676)
* non-functional: the format was never right to correctly set the metadata