### PR TITLE
fix: alignment of compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ steps:
 ## Compatibility
 
 | Elastic Stack | Agent Stack K8s | Hosted (Mac) | Hosted (Linux) | Notes |
-| :-----------: | :-------------: | :----: | :----: |:---- |
-| Custom Checkout | ✅ | ✅ | ✅ | ✅ | n/a |
+| :-----------: | :-------------: | :----------: | :------------: |:----: |
+| ✅ | ✅ | ✅ | ✅ | n/a |
 
 - ✅ Fully supported (all combinations of attributes have been tested to pass)
 - ⚠️ Partially supported (some combinations cause errors/issues)


### PR DESCRIPTION
updated to match, https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin#compatibility - previously this was shifted left by one due to the plugin name being in the first cell