### PR TITLE
Fix: Resolve multiple repository checkout conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Each repository in the `repos` list can have the following options:
 | `mirror_url`  | false    |          | Optional mirror URL for faster/local clone  |
 | `ref`         | false    |          | Branch, tag, or commit to checkout          |
 | `clone_flags` | false    | `["-v"]` | Additional flags for git clone              |
+| `checkout_path` | false  |          | Custom directory path for this repository  |
 
 ## Examples
 
@@ -101,6 +102,24 @@ steps:
               ref: "main"
             - url: "https://github.com/org/repo2.git"
               ref: "dev"
+```
+
+### Custom Checkout Paths
+
+```yaml
+steps:
+  - label: "Custom paths"
+    command: "./script.sh"
+    plugins:
+      - custom-checkout#v1.3.0:
+          skip_checkout: true
+          repos:
+            - url: "https://github.com/org/repo1.git"
+              ref: "main"
+              checkout_path: "/tmp/repo1"
+            - url: "https://github.com/org/repo2.git"
+              ref: "dev"
+              checkout_path: "repo2"
 ```
 
 ### Clone with Mirror URL

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -54,21 +54,21 @@ add_ssh_host() {
   # Check if host is already in known_hosts
   if ! grep -q "^$host" "$HOME/.ssh/known_hosts"; then
     log_info "$host not found in known_hosts"
-    
+
     # Get host key
     tmp_file=$(mktemp)
     ssh-keyscan -t rsa "$host" > "$tmp_file"
-    
+
     # Verify fingerprint
     local actual_fingerprint
     actual_fingerprint=$(ssh-keygen -lf "$tmp_file" | awk '{ print $2 }')
-    
+
     if [[ "$actual_fingerprint" != "$fingerprint" ]]; then
       log_error "Fingerprint mismatch for $host. Expected $fingerprint, got $actual_fingerprint."
       rm "$tmp_file"
       exit 1
     fi
-    
+
     # Add to known_hosts
     cat "$tmp_file" >> "$HOME/.ssh/known_hosts"
     rm "$tmp_file"
@@ -131,7 +131,7 @@ log_section ":open_file_folder: Setting up workspace"
 # Check for skip checkout
 if [[ "${BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT:-false}" == "true" ]]; then
   log_warning "🚫 Skipping default checkout as per configuration."
-  
+
   # If we're just skipping checkout and no repos are specified, exit successfully
   if [[ -z "${BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0:-}" && -z "${BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL:-}" ]]; then
     log_info "📝 No repositories configured for checkout, skipping repository checkout"
@@ -165,20 +165,21 @@ CLONE_SUCCESS=false
 while true; do
   REPO_URL_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_URL"
   REPO_MIRROR_URL_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_MIRROR_URL"
-  
+
   if [[ -z "${!REPO_URL_VAR:-}" ]]; then
     REPO_URL_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}"
     if [[ -z "${!REPO_URL_VAR:-}" ]]; then
       break
     fi
   fi
-  
+
   REPO_URL="${!REPO_URL_VAR}"
   REPO_MIRROR_URL="${!REPO_MIRROR_URL_VAR:-}"
   log_info "Processing repository $REPOS_COUNT: $REPO_URL"
-  
+
   REPO_REF_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_REF"
   REPO_SSH_KEY_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_SSH_KEY_PATH"
+  REPO_CHECKOUT_PATH_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_${REPOS_COUNT}_CHECKOUT_PATH"
 
   CLONE_FLAGS_COUNT=0
   REPO_CLONE_FLAGS=()
@@ -199,8 +200,34 @@ while true; do
 
   REPO_REF="${!REPO_REF_VAR:-}"
   REPO_SSH_KEY_PATH="${!REPO_SSH_KEY_VAR:-}"
-  
-  if clone_repository "$REPO_URL" "$REPO_REF" "$REPO_SSH_KEY_PATH" "$BUILDKITE_BUILD_CHECKOUT_PATH" "$REPO_MIRROR_URL" "${REPO_CLONE_FLAGS[@]+"${REPO_CLONE_FLAGS[@]}"}"; then
+  REPO_CHECKOUT_PATH="${!REPO_CHECKOUT_PATH_VAR:-}"
+
+  # Determine the checkout directory for this repository
+  if [[ -n "$REPO_CHECKOUT_PATH" ]]; then
+    if [[ "$REPO_CHECKOUT_PATH" = /* ]]; then
+      REPO_CLONE_DIR="$REPO_CHECKOUT_PATH"
+    else
+      REPO_CLONE_DIR="$BUILDKITE_BUILD_CHECKOUT_PATH/$REPO_CHECKOUT_PATH"
+    fi
+  else
+    REPO_NAME=$(basename "$REPO_URL" .git)
+
+    # Check if we have multiple repos
+    NEXT_REPO_URL_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_$((REPOS_COUNT + 1))_URL"
+    if [[ -z "${!NEXT_REPO_URL_VAR:-}" ]]; then
+      NEXT_REPO_URL_VAR="BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_$((REPOS_COUNT + 1))"
+    fi
+
+    if [[ $REPOS_COUNT -eq 0 && -z "${!NEXT_REPO_URL_VAR:-}" ]]; then
+      # Single repository, clone to .
+      REPO_CLONE_DIR="$BUILDKITE_BUILD_CHECKOUT_PATH"
+    else
+      # Multiple repositories, clone to ./repo
+      REPO_CLONE_DIR="$BUILDKITE_BUILD_CHECKOUT_PATH/$REPO_NAME"
+    fi
+  fi
+
+  if clone_repository "$REPO_URL" "$REPO_REF" "$REPO_SSH_KEY_PATH" "$REPO_CLONE_DIR" "$REPO_MIRROR_URL" "${REPO_CLONE_FLAGS[@]+"${REPO_CLONE_FLAGS[@]}"}"; then
     CLONE_SUCCESS=true
     log_success "Successfully cloned repository $REPO_URL"
   else

--- a/plugin.yml
+++ b/plugin.yml
@@ -35,6 +35,9 @@ configuration:
           ref:
             type: string
             description: "Branch, tag, or commit to checkout."
+          checkout_path:
+            type: string
+            description: "Directory where this repository will be cloned. Accepts relative paths (e.g., 'my-repo') for subdirectories, or absolute paths (e.g., '/tmp/checkout'). Defaults to the main directory if not specified, or relative if multiple repositories are configured."
           ssh_key_path:
             type: string
             description: "Path to SSH key for repository access."

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -119,3 +119,46 @@ teardown() {
   [ "$status" -eq 0 ]
   [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH/.git" ]
 }
+
+@test "Clone multiple repositories into separate directories" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo1.git"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_1_URL="https://github.com/example/repo2.git"
+
+  git() {
+    if [[ "$1" == "clone" ]]; then
+      local repo_url="$2"
+      mkdir -p .git
+      echo "Cloned $repo_url into $(pwd)" > .git/clone_info
+      return 0
+    else
+      command git "$@"
+    fi
+  }
+
+  run run_plugin_hook "checkout"
+
+  [ "$status" -eq 0 ]
+  [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH/repo1/.git" ]
+  [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH/repo2/.git" ]
+}
+
+@test "Clone repository with custom checkout path" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_CHECKOUT_PATH="custom-dir"
+
+  git() {
+    if [[ "$1" == "clone" ]]; then
+      mkdir -p .git
+      return 0
+    else
+      command git "$@"
+    fi
+  }
+
+  run run_plugin_hook "checkout"
+
+  [ "$status" -eq 0 ]
+  [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH/custom-dir/.git" ]
+}

--- a/tests/helper-functions.bash
+++ b/tests/helper-functions.bash
@@ -9,10 +9,10 @@ setup_environment() {
   export BUILDKITE_COMMIT="HEAD"
   export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_CHECKOUT_PATH=""
   export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_INTERPOLATE_CHECKOUT_PATH=""
-  
+
   # Ensure the plugin directory is set correctly
   export BUILDKITE_PLUGIN_DIR="${BUILDKITE_PLUGIN_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
-  
+
   # Create checkout directory
   mkdir -p "$BUILDKITE_BUILD_CHECKOUT_PATH"
 
@@ -24,7 +24,7 @@ cleanup_environment() {
   if [[ -n "${BUILDKITE_BUILD_CHECKOUT_PATH:-}" ]] && [[ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]]; then
     rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH"
   fi
-  
+
   # Unset all plugin variables
   unset BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_CHECKOUT_PATH
   unset BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_INTERPOLATE_CHECKOUT_PATH
@@ -97,4 +97,22 @@ exit 0
 EOF
 
   chmod +x "$BUILDKITE_BUILD_CHECKOUT_PATH/bin/git"
+
+# Mocking SSH-Keyscan for bats as no stub available
+  cat > "$BUILDKITE_BUILD_CHECKOUT_PATH/bin/ssh-keyscan" <<'EOF'
+echo "[mock ssh-keyscan] $@" >&2
+# Output a mock host key for github.com
+echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk="
+exit 0
+EOF
+
+  chmod +x "$BUILDKITE_BUILD_CHECKOUT_PATH/bin/ssh-keyscan"
+
+  cat > "$BUILDKITE_BUILD_CHECKOUT_PATH/bin/ssh-keygen" <<'EOF'
+echo "[mock ssh-keygen] $@" >&2
+echo "256 SHA256:uNiVztksCsDhcc0u9e8BujQXVUpKZIDTMczCvj3tD2s github.com (RSA)"
+exit 0
+EOF
+
+  chmod +x "$BUILDKITE_BUILD_CHECKOUT_PATH/bin/ssh-keygen"
 }


### PR DESCRIPTION
Fixes #25 

Multiple repositories would fail to checkout because they all tried to clone into the same directory, causing "destination path already exists" errors. As such, the logic has been updated to handle multiple directories like so:

- Single repos will now use main directory (unchanged)
- Multiple repos will automatically get their own subdirectory
- Added optional `checkout_path` option so each repository can have custom paths

