### PR TITLE
fix(checkout): reuse persistent agent repo and clean before checkout

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -91,13 +91,23 @@ clone_repository() {
   local mirror_url="${5:-}"
   local clone_flags=("${@:6}")
 
-  log_info "Cloning repository into '$clone_dir'"
-  mkdir -p "$clone_dir"
-  pushd "$clone_dir" > /dev/null
-
   if [[ -n "$ssh_key_path" ]]; then
     export GIT_SSH_COMMAND="ssh -i $ssh_key_path -o IdentitiesOnly=yes"
   fi
+
+  if [[ -e "$clone_dir/.git" ]]; then
+    log_info "Existing repository found at '$clone_dir', updating instead of re-cloning"
+    pushd "$clone_dir" > /dev/null
+    git remote set-url origin "$repo_url" || return 1
+    git fetch --all --prune || return 1
+    popd > /dev/null
+    log_success "Repository updated at '$clone_dir'"
+    return 0
+  fi
+
+  log_info "Cloning repository into '$clone_dir'"
+  mkdir -p "$clone_dir"
+  pushd "$clone_dir" > /dev/null
 
   if [[ -n "$mirror_url" ]]; then
     log_info "Trying to clone from mirror: $mirror_url"
@@ -123,6 +133,10 @@ checkout_ref() {
   local checkout_ref="$2"
 
   pushd "$clone_dir" > /dev/null
+
+  log_info "Resetting working tree to clean state"
+  git reset --hard HEAD || return 1
+  git clean -ffdx || return 1
 
   if [[ -n "$checkout_ref" ]]; then
     log_info "Checking out ref: $checkout_ref"

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -191,3 +191,124 @@ teardown() {
   grep -q -- "--depth=1" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called"
   grep -q -- "--prune" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called"
 }
+
+@test "Reuses existing repository on persistent agent instead of re-cloning" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+
+  # Simulate a pre-existing repository from a previous build (persistent agent scenario)
+  mkdir -p "$BUILDKITE_BUILD_CHECKOUT_PATH/.git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  # Verify fetch --all --prune was called (update path), not a fresh clone
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called" ]
+  grep -q -- "--all" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called"
+  grep -q -- "--prune" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called"
+}
+
+@test "Checks out correct ref on persistent agent after fetching updates" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_REF="main"
+
+  # Simulate a pre-existing repository
+  mkdir -p "$BUILDKITE_BUILD_CHECKOUT_PATH/.git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  # fetch --all --prune was called (update path taken)
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called" ]
+  grep -q -- "--all" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called"
+
+  # checkout_ref still ran and checked out the specified ref
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called" ]
+  grep -q "main" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called"
+}
+
+@test "Updates remote URL when reusing existing repository on persistent agent" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/new-location/repo.git"
+
+  # Simulate a pre-existing repository (may have had a different remote URL)
+  mkdir -p "$BUILDKITE_BUILD_CHECKOUT_PATH/.git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  # remote set-url was called with the current (possibly new) URL
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/remote_seturl_called" ]
+  grep -q "https://github.com/example/new-location/repo.git" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/remote_seturl_called"
+}
+
+@test "Resets working tree to clean state before checkout" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  # git reset --hard HEAD was called to discard any leftover changes
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/reset_called" ]
+  grep -q -- "--hard" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/reset_called"
+
+  # git clean -ffdx was called to remove untracked files
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/clean_called" ]
+  grep -q -- "-ffdx" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/clean_called"
+}
+
+@test "Reuses all existing repositories on persistent agent with multiple repos" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo1.git"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_1_URL="https://github.com/example/repo2.git"
+
+  # Both repos already exist from a previous build
+  mkdir -p "$BUILDKITE_BUILD_CHECKOUT_PATH/repo1/.git"
+  mkdir -p "$BUILDKITE_BUILD_CHECKOUT_PATH/repo2/.git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  # Both repos were updated via fetch, not re-cloned
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/repo1/.git/fetch_called" ]
+  grep -q -- "--all" "$BUILDKITE_BUILD_CHECKOUT_PATH/repo1/.git/fetch_called"
+
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/repo2/.git/fetch_called" ]
+  grep -q -- "--all" "$BUILDKITE_BUILD_CHECKOUT_PATH/repo2/.git/fetch_called"
+}
+
+@test "Fails the build when fetch fails during persistent agent repo update" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+
+  # Simulate a pre-existing repository
+  mkdir -p "$BUILDKITE_BUILD_CHECKOUT_PATH/.git"
+
+  # Override the mock to fail on fetch so we can verify error propagation
+  cat > "$BUILDKITE_BUILD_CHECKOUT_PATH/bin/git" <<'GITEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "fetch" ]]; then
+  echo "[mock git] fetch failed: network unreachable" >&2
+  exit 1
+fi
+exit 0
+GITEOF
+  chmod +x "$BUILDKITE_BUILD_CHECKOUT_PATH/bin/git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 1 ]
+}

--- a/tests/helper-functions.bash
+++ b/tests/helper-functions.bash
@@ -88,14 +88,40 @@ if [[ "$1" == "clone" ]]; then
   exit 0
 fi
 
-# Trackable fetch calls that can be read in tests, catching the command and reading it is as expected
+# Trackable fetch calls that can be read in tests
 if [[ "$1" == "fetch" ]]; then
   echo "$@" > ".git/fetch_called"
   exit 0
 fi
 
-# Simulate checkout, remote, lfs
-if [[ "$1" == "checkout" || "$1" == "remote" || "$1" == "lfs" ]]; then
+# Track checkout calls (records the ref that was checked out)
+if [[ "$1" == "checkout" ]]; then
+  echo "$@" > ".git/checkout_called"
+  exit 0
+fi
+
+# Track remote set-url calls (records the new URL)
+if [[ "$1" == "remote" ]]; then
+  if [[ "$2" == "set-url" ]]; then
+    echo "$@" > ".git/remote_seturl_called"
+  fi
+  exit 0
+fi
+
+# Track reset calls
+if [[ "$1" == "reset" ]]; then
+  echo "$@" > ".git/reset_called"
+  exit 0
+fi
+
+# Track clean calls
+if [[ "$1" == "clean" ]]; then
+  echo "$@" > ".git/clean_called"
+  exit 0
+fi
+
+# Simulate lfs
+if [[ "$1" == "lfs" ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
fix(checkout): persistent agents fail to re-clone into existing workspace directory

Problem: git clone fails on persistent agents because the workspace directory
already exists from a previous build, causing the hook to error on every
subsequent run.

Solution: detect existing .git and fetch --all --prune instead of re-cloning,
then reset and clean the working tree before checkout for a reproducible state.
