### PR TITLE
Add support for BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,19 @@ steps:
                 - "--depth=1"
 ```
 
+### Pull Request Merge Refspec
+
+When `BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC` is enabled in your pipeline, the plugin automatically fetches and checks out GitHub's pre-computed merge commit (`refs/pull/N/merge`) instead of the PR head commit. This tests the result of merging the PR into its target branch.
+
+This activates when all of the following are true:
+
+- `BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC` is `true`
+- The build is for a pull request (`BUILDKITE_PULL_REQUEST` is a number)
+- The repository URL matches `BUILDKITE_REPO`
+- No explicit `ref` is configured for the repository
+
+When using multiple repositories, merge refspec only applies to the repository that triggered the build. An explicit `ref` always takes precedence.
+
 ## Compatibility
 
 | Elastic Stack | Agent Stack K8s | Hosted (Mac) | Hosted (Linux) | Notes |

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -66,6 +66,31 @@ add_ssh_host() {
   fi
 }
 
+normalize_repo_url() {
+  local url="$1"
+  url="${url%.git}"
+  url="${url#https://}"
+  url="${url#http://}"
+  url="${url#git@}"
+  url="${url/:/\/}"
+  echo "$url" | tr '[:upper:]' '[:lower:]'
+}
+
+should_use_merge_refspec() {
+  local repo_url="$1"
+  local repo_ref="$2"
+
+  [[ "${BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC:-false}" == "true" ]] || return 1
+  [[ -n "${BUILDKITE_PULL_REQUEST:-}" && "${BUILDKITE_PULL_REQUEST}" != "false" ]] || return 1
+  [[ -z "$repo_ref" ]] || return 1
+
+  if [[ -n "${BUILDKITE_REPO:-}" ]]; then
+    [[ "$(normalize_repo_url "$repo_url")" == "$(normalize_repo_url "$BUILDKITE_REPO")" ]] || return 1
+  fi
+
+  return 0
+}
+
 fetch_commit() {
   local clone_dir="$1"
   local fetch_target="$2"
@@ -293,7 +318,18 @@ while true; do
     fi
   fi
 
-  if ! checkout_ref "$REPO_CLONE_DIR" "$REPO_REF"; then
+  # Fetch merge ref after any user-configured fetch so FETCH_HEAD points to the merge commit
+  if should_use_merge_refspec "$REPO_URL" "$REPO_REF"; then
+    if ! fetch_commit "$REPO_CLONE_DIR" "refs/pull/${BUILDKITE_PULL_REQUEST}/merge"; then
+      log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST}"
+      exit 1
+    fi
+    CHECKOUT_TARGET="FETCH_HEAD"
+  else
+    CHECKOUT_TARGET="$REPO_REF"
+  fi
+
+  if ! checkout_ref "$REPO_CLONE_DIR" "$CHECKOUT_TARGET"; then
     log_error "Failed to checkout ref for repository $REPO_URL"
     exit 1
   fi

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -320,10 +320,12 @@ while true; do
 
   # Fetch merge ref after any user-configured fetch so FETCH_HEAD points to the merge commit
   if should_use_merge_refspec "$REPO_URL" "$REPO_REF"; then
+    log_info "Merge refspec enabled for PR #${BUILDKITE_PULL_REQUEST}, fetching refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
     if ! fetch_commit "$REPO_CLONE_DIR" "refs/pull/${BUILDKITE_PULL_REQUEST}/merge"; then
       log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST}"
       exit 1
     fi
+    log_info "Checking out merge commit (FETCH_HEAD) instead of PR head"
     CHECKOUT_TARGET="FETCH_HEAD"
   else
     CHECKOUT_TARGET="$REPO_REF"

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -289,6 +289,175 @@ teardown() {
   grep -q -- "--all" "$BUILDKITE_BUILD_CHECKOUT_PATH/repo2/.git/fetch_called"
 }
 
+@test "Fetches merge ref and checks out FETCH_HEAD when merge refspec is enabled" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="42"
+  export BUILDKITE_REPO="https://github.com/example/repo.git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called" ]
+  grep -q "refs/pull/42/merge" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called"
+
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called" ]
+  grep -q "FETCH_HEAD" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called"
+}
+
+@test "Merge refspec is ignored when BUILDKITE_PULL_REQUEST is false" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="false"
+  export BUILDKITE_REPO="https://github.com/example/repo.git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called" ]
+  ! grep -q "FETCH_HEAD" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called"
+}
+
+@test "Merge refspec is ignored when flag is not set" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+  export BUILDKITE_PULL_REQUEST="42"
+  export BUILDKITE_REPO="https://github.com/example/repo.git"
+  unset BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called" ]
+  ! grep -q "FETCH_HEAD" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called"
+}
+
+@test "Explicit ref takes precedence over merge refspec" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_REF="main"
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="42"
+  export BUILDKITE_REPO="https://github.com/example/repo.git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called" ]
+  grep -q "main" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called"
+  ! grep -q "FETCH_HEAD" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called"
+}
+
+@test "Merge refspec only applies to the repo matching BUILDKITE_REPO" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo1.git"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_1_URL="https://github.com/example/repo2.git"
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="42"
+  export BUILDKITE_REPO="https://github.com/example/repo1.git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  # repo1 should use merge refspec
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/repo1/.git/fetch_called" ]
+  grep -q "refs/pull/42/merge" "$BUILDKITE_BUILD_CHECKOUT_PATH/repo1/.git/fetch_called"
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/repo1/.git/checkout_called" ]
+  grep -q "FETCH_HEAD" "$BUILDKITE_BUILD_CHECKOUT_PATH/repo1/.git/checkout_called"
+
+  # repo2 should not use merge refspec
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/repo2/.git/checkout_called" ]
+  ! grep -q "FETCH_HEAD" "$BUILDKITE_BUILD_CHECKOUT_PATH/repo2/.git/checkout_called"
+}
+
+@test "Merge refspec works on persistent agent with existing repo" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="42"
+  export BUILDKITE_REPO="https://github.com/example/repo.git"
+
+  # Simulate pre-existing repository (persistent agent)
+  mkdir -p "$BUILDKITE_BUILD_CHECKOUT_PATH/.git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called" ]
+  grep -q -- "--all" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called"
+  grep -q "refs/pull/42/merge" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called"
+
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called" ]
+  grep -q "FETCH_HEAD" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called"
+}
+
+@test "Merge refspec works with SSH BUILDKITE_REPO matching HTTPS plugin URL" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="42"
+  export BUILDKITE_REPO="git@github.com:example/repo.git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 0 ]
+
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called" ]
+  grep -q "refs/pull/42/merge" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/fetch_called"
+
+  [ -f "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called" ]
+  grep -q "FETCH_HEAD" "$BUILDKITE_BUILD_CHECKOUT_PATH/.git/checkout_called"
+}
+
+@test "Merge refspec fetch failure aborts the build" {
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
+  export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="42"
+  export BUILDKITE_REPO="https://github.com/example/repo.git"
+
+  # Override mock to fail only on merge ref fetch
+  cat > "$BUILDKITE_BUILD_CHECKOUT_PATH/bin/git" <<'GITEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "clone" ]]; then
+  mkdir -p ".git"
+  exit 0
+fi
+if [[ "$1" == "reset" ]]; then
+  exit 0
+fi
+if [[ "$1" == "clean" ]]; then
+  exit 0
+fi
+if [[ "$1" == "fetch" && "$*" == *"refs/pull"* ]]; then
+  echo "[mock git] merge ref fetch failed" >&2
+  exit 1
+fi
+exit 0
+GITEOF
+  chmod +x "$BUILDKITE_BUILD_CHECKOUT_PATH/bin/git"
+
+  run run_plugin_hook "checkout"
+
+  echo "Output: $output"
+  [ "$status" -eq 1 ]
+}
+
 @test "Fails the build when fetch fails during persistent agent repo update" {
   export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_SKIP_CHECKOUT="false"
   export BUILDKITE_PLUGIN_CUSTOM_CHECKOUT_REPOS_0_URL="https://github.com/example/repo.git"

--- a/tests/helper-functions.bash
+++ b/tests/helper-functions.bash
@@ -90,7 +90,7 @@ fi
 
 # Trackable fetch calls that can be read in tests
 if [[ "$1" == "fetch" ]]; then
-  echo "$@" > ".git/fetch_called"
+  echo "$@" >> ".git/fetch_called"
   exit 0
 fi
 


### PR DESCRIPTION
  - Add support for `BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC` to fetch and checkout
    GitHub's pre-computed merge commit (`refs/pull/N/merge`) instead of the PR head commit
  - Only applies to the repo matching `BUILDKITE_REPO`
  - Normalizes repo URLs for SSH/HTTPS comparison

Note: Defining an explicit `ref` in the plugin config will take precedence over using the merge refspec